### PR TITLE
Update maven plugin to 2.0.9.88.v20151125

### DIFF
--- a/1-helloworld/pom.xml
+++ b/1-helloworld/pom.xml
@@ -54,7 +54,7 @@ Copyright 2015 Google Inc. All Rights Reserved.
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.84.v20151031</version>
+        <version>2.0.9.88.v20151125</version>
         <configuration>
           <set_default>true</set_default>
         </configuration>

--- a/1-helloworld/src/main/java/com/example/appengine/gettingstartedjava/helloworld/HelloServlet.java
+++ b/1-helloworld/src/main/java/com/example/appengine/gettingstartedjava/helloworld/HelloServlet.java
@@ -25,10 +25,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 // [START example]
-@WebServlet(name = "helloworld", urlPatterns = { "/*" })
+@SuppressWarnings("serial")
+@WebServlet(name = "helloworld", value = "/*" )
 public class HelloServlet extends HttpServlet {
-
-  private static final long serialVersionUID = 1L;
 
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {


### PR DESCRIPTION
This should address the current issue in https://github.com/GoogleCloudPlatform/getting-started-java/pull/2 where an older version of the gcloud maven plugin cannot find the gcloud sdk.