### PR TITLE
Hide image upload when no Cloud Storage config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,15 @@
 
 # Target folders
 target/
+
+## Vim ##
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/auth/Oauth2CallbackServlet.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/auth/Oauth2CallbackServlet.java
@@ -16,6 +16,7 @@
 
 package com.example.managedvms.gettingstartedjava.auth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.auth.oauth2.TokenResponse;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
@@ -26,8 +27,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson.JacksonFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/basicactions/CreateBookServlet.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/basicactions/CreateBookServlet.java
@@ -48,7 +48,7 @@ public class CreateBookServlet extends HttpServlet {
       IOException {
     req.setAttribute(
         "isCloudStorageConfigured",             // Hide upload when Cloud Storage is not configured.
-       	!Strings.isNullOrEmpty(getServletContext().getInitParameter("bookshelf.bucket")));
+        !Strings.isNullOrEmpty(getServletContext().getInitParameter("bookshelf.bucket")));
     req.setAttribute("action", "Add");          // Part of the Header in form.jsp
     req.setAttribute("destination", "create");  // The urlPattern to invoke (this Servlet)
     req.setAttribute("page", "form");           // Tells base.jsp to include form.jsp

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/basicactions/CreateBookServlet.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/basicactions/CreateBookServlet.java
@@ -20,6 +20,8 @@ import com.example.managedvms.gettingstartedjava.daos.BookDao;
 import com.example.managedvms.gettingstartedjava.objects.Book;
 import com.example.managedvms.gettingstartedjava.util.CloudStorageHelper;
 
+import com.google.common.base.Strings;
+
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -44,6 +46,9 @@ public class CreateBookServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException,
       IOException {
+    req.setAttribute(
+        "isCloudStorageConfigured",             // Hide upload when Cloud Storage is not configured.
+       	!Strings.isNullOrEmpty(getServletContext().getInitParameter("bookshelf.bucket")));
     req.setAttribute("action", "Add");          // Part of the Header in form.jsp
     req.setAttribute("destination", "create");  // The urlPattern to invoke (this Servlet)
     req.setAttribute("page", "form");           // Tells base.jsp to include form.jsp

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/basicactions/UpdateBookServlet.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/basicactions/UpdateBookServlet.java
@@ -20,6 +20,8 @@ import com.example.managedvms.gettingstartedjava.daos.BookDao;
 import com.example.managedvms.gettingstartedjava.objects.Book;
 import com.example.managedvms.gettingstartedjava.util.CloudStorageHelper;
 
+import com.google.common.base.Strings;
+
 import java.io.IOException;
 
 import javax.servlet.ServletException;
@@ -41,6 +43,9 @@ public class UpdateBookServlet extends HttpServlet {
     BookDao dao = (BookDao) this.getServletContext().getAttribute("dao");
     try {
       Book book = dao.readBook(Long.decode(req.getParameter("id")));
+      req.setAttribute(
+          "isCloudStorageConfigured",           // Hide upload when Cloud Storage is not configured.
+          !Strings.isNullOrEmpty(getServletContext().getInitParameter("bookshelf.bucket")));
       req.setAttribute("book", book);
       req.setAttribute("action", "Edit");
       req.setAttribute("destination", "update");

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/daos/CloudSqlDao.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/daos/CloudSqlDao.java
@@ -18,6 +18,7 @@ package com.example.managedvms.gettingstartedjava.daos;
 
 import com.example.managedvms.gettingstartedjava.objects.Book;
 import com.example.managedvms.gettingstartedjava.objects.Result;
+
 import org.apache.commons.dbcp2.BasicDataSource;
 
 import java.sql.Connection;

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/daos/DatastoreDao.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/daos/DatastoreDao.java
@@ -16,6 +16,9 @@
 
 package com.example.managedvms.gettingstartedjava.daos;
 
+import com.example.managedvms.gettingstartedjava.objects.Book;
+import com.example.managedvms.gettingstartedjava.objects.Result;
+
 import com.google.gcloud.datastore.Cursor;
 import com.google.gcloud.datastore.Datastore;
 import com.google.gcloud.datastore.DatastoreOptions;
@@ -28,9 +31,6 @@ import com.google.gcloud.datastore.Query;
 import com.google.gcloud.datastore.QueryResults;
 import com.google.gcloud.datastore.StructuredQuery.OrderBy;
 import com.google.gcloud.datastore.StructuredQuery.PropertyFilter;
-
-import com.example.managedvms.gettingstartedjava.objects.Book;
-import com.example.managedvms.gettingstartedjava.objects.Result;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/bookshelf/src/main/webapp/form.jsp
+++ b/bookshelf/src/main/webapp/form.jsp
@@ -45,7 +45,8 @@ Copyright 2015 Google Inc. All Rights Reserved.
       <textarea name="description" id="description" class="form-control">${fn:escapeXml(book.description)}</textarea>
     </div>
 
-    <div class="form-group">
+    
+    <div class="form-group ${isCloudStorageConfigured ? '' : 'hidden'}">
       <label for="image">Cover Image</label>
       <input type="file" name="file" id="file" class="form-control" />
     </div>

--- a/java-repo-tools/google-checks.xml
+++ b/java-repo-tools/google-checks.xml
@@ -167,9 +167,9 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="CustomImportOrder">
-            <property name="specialImportsRegExp" value="com.google"/>
+            <property name="specialImportsRegExp" value="^javax\."/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+            <property name="customImportOrderRules" value="STATIC###SAME_PACKAGE(2)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">


### PR DESCRIPTION
We have developers run the sample without doing any configuration. It's
not a great experience if the app seems broken when they create a book
and try to include an image.

I only hide the element since the Create and Update servlets expect the
"file" property to be populated (even if it's empty string).

We should consider doing the same for the login button and "my books"
button if the client ID for OAuth2 is not set.