### PR TITLE
Create firewall rule to allow port 80 access.

### DIFF
--- a/bookshelf/makeBookshelf
+++ b/bookshelf/makeBookshelf
@@ -85,6 +85,12 @@ gce)
 
   gsutil cp -r target/${WAR} gce/base gs://${BUCKET}/gce/
 
+  gcloud compute firewall-rules create allow-http \
+    --allow tcp:80 \
+    --source-ranges 0.0.0.0/0 \
+    --target-tags http-server \
+    --description "Allow port 80 access to instances tagged with http-server"
+
   gcloud compute instances create my-app-instance \
     --machine-type=${MACHINE_TYPE} \
     --scopes=${SCOPES} \


### PR DESCRIPTION
This is created by default when checking the box in the GUI console page
when creating an instance with "Allow HTTP" checked, but it is not
created when creating an instance tagged "http-server" from the command
line.