### PR TITLE
Add lint checks to Java getting started samples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@
 language: java
 jdk:
   - oraclejdk8
-script: mvn verify
+script: mvn --batch-mode clean verify | egrep -v "(^\[INFO\] Download|^\[INFO\].*skipping)"
 after_success:
   - mvn clean cobertura:cobertura coveralls:report
 branches:

--- a/helloworld-jsp/src/main/java/org/example/appengine/hello/HelloInfo.java
+++ b/helloworld-jsp/src/main/java/org/example/appengine/hello/HelloInfo.java
@@ -23,9 +23,9 @@ package org.example.appengine.hello;
 public class HelloInfo {
 
   public static String getInfo() {
-    return "Version: "+System.getProperty("java.version") +
-          " OS: "+System.getProperty("os.name") +
-          " User: " +System.getProperty("user.name");
+    return "Version: " + System.getProperty("java.version")
+          + " OS: " + System.getProperty("os.name")
+          + " User: " + System.getProperty("user.name");
   }
 }
 // [END example]

--- a/helloworld-servlet/pom.xml
+++ b/helloworld-servlet/pom.xml
@@ -23,14 +23,14 @@
   <groupId>com.example.flex.helloworld</groupId>
   <artifactId>helloworld-servlet</artifactId> <!-- Name of your project -->
   <version>1.0-SNAPSHOT</version>       <!-- xx.xx.xx -SNAPSHOT means development -->
-    
+
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source> <!-- REQUIRED -->
     <maven.compiler.target>1.8</maven.compiler.target> <!-- REQUIRED -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
   </properties>
-  
+
   <parent>                              <!-- Get parameters and allow bulk testing -->
     <artifactId>getting-started-java</artifactId>
     <groupId>com.example.flex</groupId>

--- a/helloworld-springboot/pom.xml
+++ b/helloworld-springboot/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
 ~ Copyright (c) 2013 Google Inc. All Rights Reserved.
 ~
@@ -14,9 +13,7 @@
 ~ implied. See the License for the specific language governing
 ~ permissions and limitations under the License.
 -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project>
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.example.flex.gettingstarted</groupId>
@@ -27,11 +24,11 @@
   <name>helloworld-springboot</name>
   <description>Demo project for Spring Boot</description>
 
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.3.2.RELEASE</version>
-    <relativePath/> <!-- lookup parent from repository -->
+  <parent>                              <!-- Get parameters and allow bulk testing -->
+    <artifactId>getting-started-java</artifactId>
+    <groupId>com.example.flex</groupId>
+    <version>1.0.0</version>
+    <relativePath>..</relativePath>
   </parent>
 
   <properties>
@@ -43,20 +40,23 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <version>1.3.3.RELEASE</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <version>1.3.3.RELEASE</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>1.3.3.RELEASE</version>
       </plugin>
 <!-- START plugin -->
       <plugin>

--- a/helloworld-springboot/src/main/java/com/example/java/gettingstarted/HelloworldApplication.java
+++ b/helloworld-springboot/src/main/java/com/example/java/gettingstarted/HelloworldApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.example.java.gettingstarted;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
 @RestController

--- a/helloworld-springboot/src/test/java/com/example/java/gettingstarted/HelloworldApplicationTests.java
+++ b/helloworld-springboot/src/test/java/com/example/java/gettingstarted/HelloworldApplicationTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.example.java.gettingstarted;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = HelloworldApplication.class)

--- a/java-repo-tools/README.md
+++ b/java-repo-tools/README.md
@@ -41,6 +41,19 @@ git checkout master
 # Making a new branch ia optional, but recommended to send a pull request to
 # start using java-repo-tools.
 git checkout -b use-java-repo-tools
+```
+
+So that we can pull future updates from the `java-repo-tools` repository, we
+merge histories. This way we won't get unnecessary conflicts when pulling changes
+in.
+
+```
+git merge -s ours --no-commit java-repo-tools/master
+```
+
+Finally, read the `java-repo-tools` into a subtree.
+
+```
 git read-tree --prefix=java-repo-tools/ -u java-repo-tools
 ```
 
@@ -82,17 +95,13 @@ now-redundant plugin information.
 If you haven't done this before, run
 
 ```
-git remote add java-repo-tools
-git@github.com:GoogleCloudPlatform/java-repo-tools.git
-git fetch java-repo-tools master
-# Optional, but it makes pushing changes upstream easier.
-git checkout -b java-repo-tools java-repo-tools/master
+git remote add java-repo-tools git@github.com:GoogleCloudPlatform/java-repo-tools.git
 ```
 
 To detect if you have changes in the directory, run
 
 ```
-git fetch java-repo-tools
+git fetch java-repo-tools master
 git diff-tree -p HEAD:java-repo-tools/ java-repo-tools/master
 ```
 
@@ -111,33 +120,17 @@ directory.)
 To update the `java-repo-tools` directory, if you haven't done this before, run
 
 ```
-git remote add java-repo-tools
-git@github.com:GoogleCloudPlatform/java-repo-tools.git
-git fetch java-repo-tools master
-git checkout -b java-repo-tools java-repo-tools/master
+git remote add java-repo-tools git@github.com:GoogleCloudPlatform/java-repo-tools.git
 ```
 
-To pull the changes when in this branch run
-
-```
-git pull java-repo-tools master
-```
-
-To pull the changes back from upstream:
-
-```
-git checkout java-repo-tools
-git pull java-repo-tools master
-```
-
-Pull them into the main code.
+To pull the latest changes from this `java-repo-tools` repository, run:
 
 ```
 git checkout master
 # Making a new branch is optional, but recommended to send a pull request for
 # update.
 git checkout -b update-java-repo-tools
-git merge --squash -Xsubtree=java-repo-tools/ --no-commit java-repo-tools
+git pull -s subtree java-repo-tools master
 ```
 
 Then you can make any needed changes to make the rest of the repository
@@ -170,6 +163,10 @@ git push java-repo-tools java-repo-tools:name-for-remote-branch
 
 Then, you can send a pull request to the `java-repo-tools` repository.
 
+
+## References
+
+- [GitHub's subtree merge reference](https://help.github.com/articles/about-git-subtree-merges/)
 
 ## Contributing changes
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,9 @@ limitations under the License.
 
     <modules>
         <module>bookshelf</module>
+        <module>helloworld-jsp</module>
+        <module>helloworld-servlet</module>
+        <module>helloworld-springboot</module>
     </modules>
 
     <reporting>


### PR DESCRIPTION
Add lint checks to Java getting started samples.

Sorry for the extra commits. ☹ I had to merge histories to keep `java-repo-tools` subtree in sync without causing every change to be a conflict. 