### PR TITLE
Update gcloud-java dependency and package names

### DIFF
--- a/bookshelf/pom.xml
+++ b/bookshelf/pom.xml
@@ -98,9 +98,9 @@ Copyright 2015 Google Inc. All Rights Reserved.
     </dependency>
 
     <dependency>                        <!-- Google Cloud Client Library for Java -->
-      <groupId>com.google.gcloud</groupId>
+      <groupId>com.google.cloud</groupId>
       <artifactId>gcloud-java</artifactId>
-      <version>0.1.7</version>
+      <version>0.2.0</version>
     </dependency>
 
     <dependency>                        <!-- Google API client - for stuff that's not in gcloud-->

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/daos/DatastoreDao.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/daos/DatastoreDao.java
@@ -16,6 +16,9 @@
 
 package com.example.managedvms.gettingstartedjava.daos;
 
+import com.example.managedvms.gettingstartedjava.objects.Book;
+import com.example.managedvms.gettingstartedjava.objects.Result;
+
 import com.google.cloud.datastore.Cursor;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
@@ -28,9 +31,6 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery.OrderBy;
 import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
-
-import com.example.managedvms.gettingstartedjava.objects.Book;
-import com.example.managedvms.gettingstartedjava.objects.Result;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/daos/DatastoreDao.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/daos/DatastoreDao.java
@@ -16,21 +16,21 @@
 
 package com.example.managedvms.gettingstartedjava.daos;
 
+import com.google.cloud.datastore.Cursor;
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.FullEntity;
+import com.google.cloud.datastore.IncompleteKey;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.StructuredQuery.OrderBy;
+import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
+
 import com.example.managedvms.gettingstartedjava.objects.Book;
 import com.example.managedvms.gettingstartedjava.objects.Result;
-
-import com.google.gcloud.datastore.Cursor;
-import com.google.gcloud.datastore.Datastore;
-import com.google.gcloud.datastore.DatastoreOptions;
-import com.google.gcloud.datastore.Entity;
-import com.google.gcloud.datastore.FullEntity;
-import com.google.gcloud.datastore.IncompleteKey;
-import com.google.gcloud.datastore.Key;
-import com.google.gcloud.datastore.KeyFactory;
-import com.google.gcloud.datastore.Query;
-import com.google.gcloud.datastore.QueryResults;
-import com.google.gcloud.datastore.StructuredQuery.OrderBy;
-import com.google.gcloud.datastore.StructuredQuery.PropertyFilter;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/util/CloudStorageHelper.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/util/CloudStorageHelper.java
@@ -16,12 +16,12 @@
 
 package com.example.managedvms.gettingstartedjava.util;
 
-import com.google.gcloud.storage.Acl;
-import com.google.gcloud.storage.Acl.Role;
-import com.google.gcloud.storage.Acl.User;
-import com.google.gcloud.storage.BlobInfo;
-import com.google.gcloud.storage.Storage;
-import com.google.gcloud.storage.StorageOptions;
+import com.google.cloud.storage.Acl;
+import com.google.cloud.storage.Acl.Role;
+import com.google.cloud.storage.Acl.User;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;

--- a/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/util/DatastoreSessionFilter.java
+++ b/bookshelf/src/main/java/com/example/managedvms/gettingstartedjava/util/DatastoreSessionFilter.java
@@ -1,17 +1,17 @@
 package com.example.managedvms.gettingstartedjava.util;
 
+import com.google.cloud.datastore.Datastore;
+import com.google.cloud.datastore.DatastoreOptions;
+import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.Key;
+import com.google.cloud.datastore.KeyFactory;
+import com.google.cloud.datastore.Query;
+import com.google.cloud.datastore.QueryResults;
+import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
+import com.google.cloud.datastore.Transaction;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
-import com.google.gcloud.datastore.Datastore;
-import com.google.gcloud.datastore.DatastoreOptions;
-import com.google.gcloud.datastore.Entity;
-import com.google.gcloud.datastore.Key;
-import com.google.gcloud.datastore.KeyFactory;
-import com.google.gcloud.datastore.Query;
-import com.google.gcloud.datastore.QueryResults;
-import com.google.gcloud.datastore.StructuredQuery.PropertyFilter;
-import com.google.gcloud.datastore.Transaction;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;


### PR DESCRIPTION
gcloud-java renamed it's group id and changed it's packaging from com.google.gcloud to com.google.cloud in the latest release.  This PR updates bookshelf to pick up those changes.