### PR TITLE
Recommend `jetty:run-exploded` for local Hello World.

### DIFF
--- a/helloworld-servlet/README.md
+++ b/helloworld-servlet/README.md
@@ -8,7 +8,7 @@
 ## Run the Application locally
 1. Set the correct Cloud SDK project via `gcloud config set project YOUR_PROJECT`
 id of your application.
-2. Run `mvn gcloud:run`
+2. Run `mvn jetty:run-exploded`
 4. Visit http://localhost:8080
 
 ## Deploy to AppEngine Managed VMs


### PR DESCRIPTION
Using the `gcloud:run` plugin fails because it is looking for
`appengine-web.xml`.

```
$ mvn gcloud:run
...
[ERROR]
com.google.apphosting.utils.config.AppEngineConfigException: Could not locate /usr/local/google/home/swast/src/getting-started-java/helloworld-servlet/target/helloworld-servlet-1.0-SNAPSHOT/WEB-INF/appengine-web.xml
        at com.google.apphosting.utils.config.AppEngineWebXmlReader.getInputStream(AppEngineWebXmlReader.java:141)
        at com.google.apphosting.utils.config.AppEngineWebXmlReader.readAppEngineWebXml(AppEngineWebXmlReader.java:75)
        at com.google.appengine.gcloudapp.AbstractGcloudMojo.getAppEngineWebXml(AbstractGcloudMojo.java:576)
        at com.google.appengine.gcloudapp.AbstractGcloudMojo.executeAppCfgStagingCommand(AbstractGcloudMojo.java:663)
        at com.google.appengine.gcloudapp.GCloudAppRun.getCommand(GCloudAppRun.java:325)
        at com.google.appengine.gcloudapp.GCloudAppRun.execute(GCloudAppRun.java:290)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.io.FileNotFoundException: /usr/local/google/home/swast/src/getting-started-java/helloworld-servlet/target/helloworld-servlet-1.0-SNAPSHOT/WEB-INF/appengine-web.xml (No such file or directory)
        at java.io.FileInputStream.open0(Native Method)
        at java.io.FileInputStream.open(FileInputStream.java:195)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at java.io.FileInputStream.<init>(FileInputStream.java:93)
        at com.google.apphosting.utils.config.AppEngineWebXmlReader.getInputStream(AppEngineWebXmlReader.java:137)
        ... 27 more
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.432 s
[INFO] Finished at: 2016-06-10T14:41:59-07:00
[INFO] Final Memory: 19M/290M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.google.appengine:gcloud-maven-plugin:2.0.9.111.v20160525:run (default-cli) on project helloworld-servlet: Execution error: com.google.apphosting.utils.config.AppEngineConfigException: Could not locate /usr/local/google/home/swast/src/getting-started-java/helloworld-servlet/target/helloworld-servlet-1.0-SNAPSHOT/WEB-INF/appengine-web.xml -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```