### PR TITLE
Fix for gcloud:deploy failure. Was not creating an executable .jar file.

### DIFF
--- a/helloworld-springboot/pom.xml
+++ b/helloworld-springboot/pom.xml
@@ -57,6 +57,18 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>1.3.3.RELEASE</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>1.3.3.RELEASE</version>
       </plugin>
 <!-- START plugin -->
       <plugin>


### PR DESCRIPTION
Running `mvn gcloud:deploy` on the pristine helloworld-springboot project would fail with:

```
...
[INFO] Updating service [default]...
[INFO]                              
[INFO] Updating service [default]...failed.
[INFO] ERROR: (gcloud.preview.app.deploy) Error Response: [13] Timed out when starting VMs.  It's possible that the application code is unhealthy.  (0/1 ready, 1 still deploying).
[ERROR] Error: gcloud app command with exit code : 1
```

I finally found in the gcloud log files that the main manifest attribute was missing.

Can see similar errors with `mvn package` followed by `java -jar target/helloworld-springboot-0.0.1-SNAPSHOT.jar'
