### PR TITLE
Exit script on errors.

### DIFF
--- a/bookshelf/6-gce/gce/startup-script.sh
+++ b/bookshelf/6-gce/gce/startup-script.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 # [START script]
+set -e
 set -v
 
 # Talk to the metadata server to get the project id


### PR DESCRIPTION
There was an update to shellcheck, so Travis started failing with error [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164). The `cd` command can fail, so it was looking for proper error handling of this case.

It appears to me that most of the other commands can also fail in this
startup script, and we don't really want to continue if any of them does
fail, so I add the `set -e` option. This exits the script if there is an
error and also silences this shellcheck error.

@lesv PTAL