### PR TITLE
Typos + import formatting improvements

### DIFF
--- a/helloworld-compat/build.gradle
+++ b/helloworld-compat/build.gradle
@@ -22,11 +22,15 @@ buildscript {    // Configuration for building
   }
 }
 
-repositories {   // repositories for Jar's you access in your code
-  maven { 
+repositories {   // repositories for JARs you access in your code
+  maven {
     url 'https://maven-central.storage.googleapis.com'             // Google's mirror of Maven Central
-//   url 'https://oss.sonatype.org/content/repositories/snapshots' // SNAPSHOT Reposiotry (if needed)
   }
+
+//maven {
+//  url 'https://oss.sonatype.org/content/repositories/snapshots' // SNAPSHOT repository if needed
+//}
+
   jcenter()
   mavenCentral()
 }
@@ -60,6 +64,6 @@ model {
 group = 'com.example.appengine.helloworld-compat'   // Generated output GroupId
 version = '1.0-SNAPSHOT'          // Version in generated output
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 // [END gradle]

--- a/helloworld-jsp/build.gradle
+++ b/helloworld-jsp/build.gradle
@@ -23,11 +23,15 @@ buildscript {      // Configuration for building
   }
 }
 
-repositories {   // repositories for Jar's you access in your code
-  maven { 
+repositories {   // repositories for JARs you access in your code
+  maven {
     url 'https://maven-central.storage.googleapis.com'             // Google's mirror of Maven Central
-//   url 'https://oss.sonatype.org/content/repositories/snapshots' // SNAPSHOT Reposiotry (if needed)
   }
+
+//maven {
+//  url 'https://oss.sonatype.org/content/repositories/snapshots' // SNAPSHOT repository if needed
+//}
+
   jcenter()
   mavenCentral()
 }
@@ -68,6 +72,6 @@ model {
 group = 'com.example.appengine.helloworld-jsp'   // Generated output GroupId
 version = '1.0-SNAPSHOT'          // Version in generated output
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 // [END gradle]

--- a/helloworld-servlet/build.gradle
+++ b/helloworld-servlet/build.gradle
@@ -23,11 +23,15 @@ buildscript {      // Configuration for building
   }
 }
 
-repositories {   // repositories for Jar's you access in your code
-  maven { 
+repositories {   // repositories for JARs you access in your code
+  maven {
     url 'https://maven-central.storage.googleapis.com'             // Google's mirror of Maven Central
-//   url 'https://oss.sonatype.org/content/repositories/snapshots' // SNAPSHOT Reposiotry (if needed)
   }
+
+//maven {
+//  url 'https://oss.sonatype.org/content/repositories/snapshots' // SNAPSHOT repository if needed
+//}
+
   jcenter()
   mavenCentral()
 }


### PR DESCRIPTION
Now a user can cleanly uncomment the the Sonatype snapshot repo block rather than having to create a separate declaration. Saves a few seconds effort but the resulting files look better, too.