### PR TITLE
Fix typo in the bookshelf GCE example

### DIFF
--- a/bookshelf/6-gce/makeBookshelf
+++ b/bookshelf/6-gce/makeBookshelf
@@ -34,7 +34,7 @@ MAX_INSTANCES=10
 TARGET_UTILIZATION=0.6
 
 SERVICE=frontend-web-service
-WAR=bookshelf-1.0-SNAPSHOT.war
+WAR=bookshelf-6-1.0-SNAPSHOT.war
 # [END useful]
 
 function print_usage() {


### PR DESCRIPTION
This was causing the makeBookshelf script to fail