### PR TITLE
remove "service jetty status" from startup script.

### DIFF
--- a/bookshelf/6-gce/gce/startup-script.sh
+++ b/bookshelf/6-gce/gce/startup-script.sh
@@ -74,7 +74,6 @@ systemctl daemon-reload
 curl -s "https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh" | bash
 service google-fluentd restart &
 
-service jetty status
 service jetty start
 service jetty check
 


### PR DESCRIPTION
the command 

> service jetty status

when jetty is not running returns an exit code of "3" which will cause the startup script to exit prematurely before jetty has started. 

Jan 12 03:31:25 my-app-instance startup-script: INFO startup-script: ● jetty.service - SYSV: Jetty 9 webserver
Jan 12 03:31:25 my-app-instance startup-script: INFO startup-script:    Loaded: loaded (/etc/init.d/jetty)
Jan 12 03:31:25 my-app-instance startup-script: INFO startup-script:    Active: inactive (dead)
Jan 12 03:32:26 my-app-instance startup-script: INFO startup-script: Return code 3.

This change just removes that command and just starts jetty.