### PR TITLE
Fix deprecated host parameter

### DIFF
--- a/helloworld-servlet/build.gradle
+++ b/helloworld-servlet/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
 // [START gretty]
 gretty {
-    port = 8080
+    httpPort = 8080
     contextPath = '/'
     servletContainer = 'jetty9'  // What App Engine Flexible uses
 }


### PR DESCRIPTION
Gretty host property is deprecated, please use httpPort instead

http://akhikhl.github.io/gretty-doc/Gretty-configuration.html
