### PR TITLE
Fix gcloud commands for GCE deployment

### DIFF
--- a/bookshelf/6-gce/makeBookshelf
+++ b/bookshelf/6-gce/makeBookshelf
@@ -181,7 +181,7 @@ gce-many)
 
 # [START create_backend_service]
   gcloud compute backend-services create $SERVICE \
-    --http-health-check ah-health-check
+    --http-health-checks ah-health-check
 # [END create_backend_service]
 
 # [START add_backend_service]


### PR DESCRIPTION
Context: https://github.com/GoogleCloudPlatform/golang-samples/pull/205/files

(side note: I don't see where this create named ports, perhaps you're not using them?)