### PR TITLE
Make bookshelf-standard examples import into Eclipse

### DIFF
--- a/bookshelf-standard/2-structured-data/src/main/webapp/WEB-INF/web.xml
+++ b/bookshelf-standard/2-structured-data/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,11 @@
  limitations under the License.
 -->
 <!-- [START webxml] -->
-<web-app version="3.0">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" 
+         version="2.5">
     <!--
       A web.xml is needed to explicitly set the order in which filters process requests. Any filters
       not included in web.xml will be loaded after filters listed below.

--- a/bookshelf-standard/3-binary-data/src/main/webapp/WEB-INF/web.xml
+++ b/bookshelf-standard/3-binary-data/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,11 @@
  limitations under the License.
 -->
 <!-- [START webxml] -->
-<web-app version="3.0">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" 
+         version="2.5">
     <!--
       A web.xml is needed to explicitly set the order in which filters process requests. Any filters
       not included in web.xml will be loaded after filters listed below.

--- a/bookshelf-standard/4-auth/src/main/webapp/WEB-INF/web.xml
+++ b/bookshelf-standard/4-auth/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,11 @@
  limitations under the License.
 -->
 <!-- [START webxml] -->
-<web-app version="3.0">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" 
+         version="2.5">
     <!--
       A web.xml is needed to explicitly set the order in which filters process requests. Any filters
       not included in web.xml will be loaded after filters listed below.

--- a/bookshelf-standard/5-logging/src/main/webapp/WEB-INF/web.xml
+++ b/bookshelf-standard/5-logging/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,11 @@
  limitations under the License.
 -->
 <!-- [START webxml] -->
-<web-app version="3.0">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" 
+         version="2.5">
     <!--
       A web.xml is needed to explicitly set the order in which filters process requests. Any filters
       not included in web.xml will be loaded after filters listed below.

--- a/bookshelf-standard/pom.xml
+++ b/bookshelf-standard/pom.xml
@@ -71,6 +71,20 @@ Copyright 2016 Google Inc.
     </profile>
   </profiles>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>2.2</version>
+        <configuration>
+          <!-- explicitly specified to help m2e-wtp (http://eclip.se/514577) -->
+          <filteringDeploymentDescriptors>${maven.war.filteringDeploymentDescriptors}</filteringDeploymentDescriptors> 
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencyManagement>
     <dependencies>
       <!-- Selenium v3.3.1 depends on Guava v21, which doesn't support Java7 -->

--- a/pom.xml
+++ b/pom.xml
@@ -172,4 +172,42 @@ limitations under the License.
         </dependency>
       </dependencies>
     </dependencyManagement>
+
+    <build>
+      <pluginManagement>
+        <plugins>
+          <!-- m2eclipse does not support errorprone -->
+          <plugin>
+            <groupId>org.eclipse.m2e</groupId>
+            <artifactId>lifecycle-mapping</artifactId>
+            <version>1.0.0</version>
+            <configuration>
+              <lifecycleMappingMetadata>
+                <pluginExecutions>
+                  <pluginExecution>
+                    <pluginExecutionFilter>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <versionRange>[3.3,)</versionRange>
+                      <goals>
+                        <goal>compile</goal>
+                        <goal>testCompile</goal>
+                      </goals>
+                      <parameters>
+                        <compilerId>javac-with-errorprone</compilerId>
+                      </parameters>
+                    </pluginExecutionFilter>
+                    <action>
+                      <configurator>
+                        <id>org.eclipse.m2e.jdt.javaConfigurator</id>
+                      </configurator>
+                    </action>
+                  </pluginExecution>
+                </pluginExecutions>
+              </lifecycleMappingMetadata>
+            </configuration>
+          </plugin>    
+        </plugins>
+      </pluginManagement> 
+    </build>
 </project>


### PR DESCRIPTION
We hit a couple of issues when [importing the _bookshelf-standard_ examples into Eclipse](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1557):

  1. The _bookshelf-standard_ `web.xml` files are missing the required schema details and claim to require Servlet API 3.0, whereas App Engine Standard only support 2.5 at the moment.
  2. M2Eclipse needs some help to deal with using _errorprone_.
  3. M2Eclipse doesn't ([currently](https://bugs.eclipse.org/bugs/show_bug.cgi?id=514577)) support using the `maven.war.filteringDeploymentDescriptors` user property to control filtering of the `web.xml`.  It turns out that the `maven-war-plugin` 3.0 has removed this user property.