### PR TITLE
Fix jetty version

### DIFF
--- a/bookshelf/pom.xml
+++ b/bookshelf/pom.xml
@@ -31,7 +31,7 @@ Copyright 2016 Google Inc.
   </parent>
 
   <properties>
-    <jetty.maven.plugin>9.3.8.v20160314</jetty.maven.plugin>
+    <jetty.maven.plugin>9.4.3.v20170317</jetty.maven.plugin>
   </properties>
 
   <profiles>

--- a/helloworld-jsp/pom.xml
+++ b/helloworld-jsp/pom.xml
@@ -33,7 +33,7 @@
 
     <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
     <appengine.maven.plugin>1.0.0</appengine.maven.plugin>
-    <jetty.maven.plugin>9.3.7.v20160115</jetty.maven.plugin>
+    <jetty.maven.plugin>9.4.3.v20170317</jetty.maven.plugin>
   </properties>
 
   <parent>                              <!-- Get parameters and allow bulk testing -->

--- a/helloworld-servlet/pom.xml
+++ b/helloworld-servlet/pom.xml
@@ -31,7 +31,7 @@
 
     <failOnMissingWebXml>false</failOnMissingWebXml> <!-- REQUIRED -->
     <appengine.maven.plugin>1.0.0</appengine.maven.plugin>
-    <jetty.maven.plugin>9.3.8.v20160314</jetty.maven.plugin>
+    <jetty.maven.plugin>9.4.3.v20170317</jetty.maven.plugin>
   </properties>
 
   <parent>                              <!-- Get parameters and allow bulk testing -->


### PR DESCRIPTION
Quickstart tutorial is failing: https://cloud.google.com/appengine/docs/flexible/java/quickstart

Updated to latest Jetty Maven plugin