### PR TITLE
gke: GCLOUD_PROJECT env is not necessary

### DIFF
--- a/bookshelf/optional-container-engine/bookshelf-frontend.yaml
+++ b/bookshelf/optional-container-engine/bookshelf-frontend.yaml
@@ -46,11 +46,6 @@ spec:
         # off in production.
         imagePullPolicy: Always
 
-        env:
-        - name: GCLOUD_PROJECT
-          # Replace [GCLOUD_PROJECT] with your project ID.
-          value: "[GCLOUD_PROJECT]"
-
         # The bookshelf process listens on port 8080 for web traffic by default.
         ports:
         - name: http-server


### PR DESCRIPTION
I didn't realize the project should be packaged with `-DprojectID`.
Doing so eliminates the need for this GCLOUD_PROJECT env var
I added in the last PR.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>