### PR TITLE
use jessie-backport for openjdk install

### DIFF
--- a/bookshelf/6-gce/gce/startup-script.sh
+++ b/bookshelf/6-gce/gce/startup-script.sh
@@ -28,7 +28,7 @@ gsutil cp "gs://${BUCKET}/gce/"** .
 
 # Install dependencies from apt
 apt-get update
-apt-get install  -yq openjdk-8-jdk
+apt-get install -t jessie-backports -yq openjdk-8-jdk
 
 # Make Java8 the default
 update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java


### PR DESCRIPTION
Fails in installing on Debian-8 without explicitly setting the backport type.
https://packages.debian.org/jessie-backports/openjdk-8-jdk