### PR TITLE
Increasing machine size from f1-micro to g1-small.

### DIFF
--- a/bookshelf/6-gce/makeBookshelf
+++ b/bookshelf/6-gce/makeBookshelf
@@ -1,13 +1,13 @@
 #!/bin/bash
 #
 #    Copyright 2016 Google, Inc.
-# 
+#
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
 #    You may obtain a copy of the License at
-# 
+#
 #        http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #    Unless required by applicable law or agreed to in writing, software
 #    distributed under the License is distributed on an "AS IS" BASIS,
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,8 +23,9 @@ ZONE=us-central1-f
 
 GROUP=frontend-group
 TEMPLATE=$GROUP-tmpl
-MACHINE_TYPE=f1-micro
-IMAGE=debian-8
+MACHINE_TYPE=g1-small
+IMAGE_FAMILY=debian-8
+IMAGE_PROJECT=debian-cloud
 STARTUP_SCRIPT=gce/startup-script.sh
 SCOPES="datastore,userinfo-email,logging-write,storage-full,cloud-platform"
 TAGS=http-server
@@ -67,7 +68,7 @@ case $COMMAND in
 run)
   set -v
 # [START run-local]
-  mvn -Plocal clean jetty:run-exploded 
+  mvn -Plocal clean jetty:run-exploded
 # [END run-local]
   ;;
 
@@ -97,7 +98,8 @@ gce)
     --metadata-from-file startup-script=${STARTUP_SCRIPT} \
     --zone=${ZONE} \
     --tags=${TAGS} \
-    --image=${IMAGE} \
+    --image-family=${IMAGE_FAMILY} \
+    --image-project=${IMAGE_PROJECT} \
     --metadata BUCKET=${BUCKET}
 # [END gce-single]
   ;;
@@ -122,12 +124,13 @@ gce-many)
 # to create new instances.
 
 # [START create_template]
-  gcloud compute instance-templates create $TEMPLATE \
-    --image $IMAGE \
-    --machine-type $MACHINE_TYPE \
-    --scopes $SCOPES \
-    --metadata-from-file startup-script=$STARTUP_SCRIPT \
-    --tags $TAGS \
+  gcloud compute instance-templates create ${TEMPLATE} \
+    --image-family=${IMAGE_FAMILY} \
+    --image-project=${IMAGE_PROJECT} \
+    --machine-type=${MACHINE_TYPE} \
+    --scopes=${SCOPES} \
+    --metadata-from-file startup-script=${STARTUP_SCRIPT} \
+    --tags ${TAGS} \
     --metadata BUCKET=${BUCKET}
 # [END create_template]
 
@@ -143,11 +146,11 @@ gce-many)
 
 # [START create_group]
   gcloud compute instance-groups managed \
-    create $GROUP \
-    --base-instance-name $GROUP \
-    --size $MIN_INSTANCES \
-    --template $TEMPLATE \
-    --zone $ZONE 
+    create ${GROUP} \
+    --base-instance-name ${GROUP} \
+    --size ${MIN_INSTANCES} \
+    --template ${TEMPLATE} \
+    --zone ${ZONE}
 # [END create_group]
 
 #
@@ -220,7 +223,7 @@ gce-many)
     $GROUP \
     --max-num-replicas $MAX_INSTANCES \
     --target-load-balancing-utilization $TARGET_UTILIZATION \
-    --zone $ZONE 
+    --zone $ZONE
 # [END set_autoscaling]
 
   ;;


### PR DESCRIPTION
Increasing memory size from f1-micro to g1-small as frequent failures due to insufficient memory errors. 

- Removed white space and changed use of deprecated `--image` parameter for `--image-family` and `--image-project`
