### PR TITLE
Modified bookshelf.bucket property to use myBucketName instead of using projectId

### DIFF
--- a/bookshelf/6-gce/README.md
+++ b/bookshelf/6-gce/README.md
@@ -22,10 +22,10 @@ details.
 
         gcloud init
 
-* Update the `pom.xml` update properties `projectID` and `bookshelf.bucket` with
+* In the `pom.xml` update properties `projectID` and `bookshelf.bucket` with
   your project id and your bucket name respectively.
 
-* Inside the `makeBookshelf` script update the `BUCKET` environment variable
+* In the `makeBookshelf` script update the `BUCKET` environment variable
   with your bucket name.
 
 * Deploy your App

--- a/bookshelf/6-gce/README.md
+++ b/bookshelf/6-gce/README.md
@@ -10,19 +10,28 @@ referred to below as `MY-BUCKET`. You'll also need to create an OAuth2 client
 and secret, and edit `pom.xml` with its values. See the [tutorial][tutorial] for
 details.
 
-[tutorial]: https://cloud.google.com/java/getting-started/tutorial-app
-
 ### Running Locally
 
     mvn clean jetty:run-exploded \
-        -Dbookshelf.bucket=MY-BUCKET
+        -DprojectID=YOUR-PROJECT-ID \
+        -Dbookshelf.bucket=YOUR-BUCKET-NAME
 
 ### Deploying to App Engine Flexible
 
-* Initialize the [Google Cloud SDK]()
+* Initialize the [Google Cloud SDK][cloud_sdk]
 
         gcloud init
+
+* Update the `pom.xml` update properties `projectID` and `bookshelf.bucket` with
+  your project id and your bucket name respectively.
+
+* Inside the `makeBookshelf` script update the `BUCKET` environment variable
+  with your bucket name.
 
 * Deploy your App
 
         ./makeBookshelf gce
+
+[cloud_sdk]: https://cloud.google.com/sdk/
+[tutorial]: https://cloud.google.com/java/getting-started/tutorial-app
+[create-bucket]: https://cloud.google.com/storage/docs/creating-buckets#storage-create-bucket-console

--- a/bookshelf/6-gce/pom.xml
+++ b/bookshelf/6-gce/pom.xml
@@ -43,7 +43,7 @@ Copyright 2016 Google Inc.
     <sql.userName>root</sql.userName>                         <!-- A reasonable default -->
     <sql.password>myRootPassword1234</sql.password> <!-- -Dsql.password=myRootPassword1234 -->
 
-    <bookshelf.bucket>myBucketName</bookshelf.bucket> <!-- bucket w/o gs:// -->
+    <bookshelf.bucket>BUCKETNAME</bookshelf.bucket> <!-- bucket w/o gs:// -->
 
     <callback.host></callback.host> <!-- Typically projectname.appspot.com -->
     <bookshelf.clientID></bookshelf.clientID>             <!-- for User Authentication -->

--- a/bookshelf/6-gce/pom.xml
+++ b/bookshelf/6-gce/pom.xml
@@ -43,7 +43,7 @@ Copyright 2016 Google Inc.
     <sql.userName>root</sql.userName>                         <!-- A reasonable default -->
     <sql.password>myRootPassword1234</sql.password> <!-- -Dsql.password=myRootPassword1234 -->
 
-    <bookshelf.bucket>${projectID}</bookshelf.bucket> <!-- bucket w/o gs:// -->
+    <bookshelf.bucket>myBucketName</bookshelf.bucket> <!-- bucket w/o gs:// -->
 
     <callback.host></callback.host> <!-- Typically projectname.appspot.com -->
     <bookshelf.clientID></bookshelf.clientID>             <!-- for User Authentication -->


### PR DESCRIPTION
The current instruction at https://cloud.google.com/java/tutorials/bookshelf-on-compute-engine doesn't expect/suggest the user should use the project-id as the bucket name. So I updated the value of the `bookshelf.bucket` to be `myBucketName` instead. 

