### PR TITLE
Region tag modification for documentation

### DIFF
--- a/bookshelf-standard/4-auth/src/main/java/com/example/getstarted/auth/LoginServlet.java
+++ b/bookshelf-standard/4-auth/src/main/java/com/example/getstarted/auth/LoginServlet.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// [START example]
 package com.example.getstarted.auth;
 
 import com.google.appengine.api.users.User;
@@ -27,7 +26,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-
+// [START example]
 @SuppressWarnings("serial")
 public class LoginServlet extends HttpServlet {
   @Override


### PR DESCRIPTION
Move the top region tag so all the imported classes are not displayed in documentation.