### PR TITLE
Proper way to set up logging property in appengine-web.xml

### DIFF
--- a/appengine-standard-java8/springboot-appengine-standard/README.md
+++ b/appengine-standard-java8/springboot-appengine-standard/README.md
@@ -144,11 +144,13 @@ With Spring Boot >= 1.5.6, you may run into out of memory errors on startup.
 Please follow these instructions to work around this issue:
 
 1. Inside src/main/resources, adding a logging.properties file with:
-```
+```ini
 .level = INFO
 ```
 2. Inside src/main/webapp/WEB-INF/appengine-web.xml, add a config that points to the new logging.properties file.
-```
-<property name="java.util.logging.config.file" value="WEB-INF/classes/logging.properties"/>
+```xml
+<system-properties>
+  <property name="java.util.logging.config.file" value="WEB-INF/classes/logging.properties"/>
+</system-properties>
 ```
 

--- a/appengine-standard-java8/springboot-appengine-standard/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/appengine-standard-java8/springboot-appengine-standard/src/main/webapp/WEB-INF/appengine-web.xml
@@ -14,5 +14,7 @@ limitations under the License.
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <threadsafe>true</threadsafe>
   <runtime>java8</runtime>
-  <property name="java.util.logging.config.file" value="WEB-INF/classes/logging.properties"/>
+  <system-properties>
+    <property name="java.util.logging.config.file" value="WEB-INF/classes/logging.properties"/>
+  </system-properties>    
 </appengine-web-app>


### PR DESCRIPTION
appengine-web.xml syntax changed so logging property is not set correctly.
Please refer to https://cloud.google.com/appengine/docs/standard/java/config/appref#syntax