### PR TITLE
Fix reading of interpolated property in bookshelf web.xml

### DIFF
--- a/bookshelf/2-structured-data/pom.xml
+++ b/bookshelf/2-structured-data/pom.xml
@@ -184,6 +184,24 @@ Copyright 2016 Google Inc.
         <artifactId>appengine-maven-plugin</artifactId>
         <version>${appengine.maven.plugin}</version>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <webResources>
+            <resource>
+              <filtering>true</filtering>
+              <directory>src/main/webapp</directory>
+              <includes>
+                <include>**/web.xml</include>
+              </includes>
+            </resource>
+          </webResources>
+          <warSourceDirectory>src/main/webapp</warSourceDirectory>
+          <webXml>src/main/webapp/WEB-INF/web.xml</webXml>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Fix reading of interpolated property ${bookshelf.storageType} in bookshelf/2-structured-data web.xml.

Checked the [param value string](https://github.com/GoogleCloudPlatform/getting-started-java/blob/master/bookshelf/2-structured-data/src/main/java/com/example/getstarted/basicactions/ListBookServlet.java#L45) for "bookshelf.storageType" in ListBookServlet.init and it was the literal "${bookshelf.storageType}". 

Adding the maven-war-plugin allows interpolated property values in web.xml. 

Tested with `mvn jetty:run-exploded`.
Verified with `mvn appengine:deploy'. See [dzlier-work.appspot.com](https://dzlier-work.appspot.com/)