### PR TITLE
Update import package for SpringBootServletInitializer

### DIFF
--- a/appengine-standard-java8/springboot-appengine-standard/src/main/java/com/example/appengine/demos/springboot/ServletInitializer.java
+++ b/appengine-standard-java8/springboot-appengine-standard/src/main/java/com/example/appengine/demos/springboot/ServletInitializer.java
@@ -16,7 +16,7 @@
 package com.example.appengine.demos.springboot;
 
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 public class ServletInitializer extends SpringBootServletInitializer {
 


### PR DESCRIPTION
Auto dependency update bot updated spring boot v1.x -> v2.0.0, which caused some inconsistency, i.e. SpringBootServletInitializer has been moved from `org.springframework.boot.web.support.SpringBootServletInitializer`
to `org.springframework.boot.web.servlet.support.SpringBootServletInitializer`
(check: 
`https://docs.spring.io/spring-boot/docs/1.5.x/api/org/springframework/boot/web/support/SpringBootServletInitializer.html`
VS
`https://docs.spring.io/spring-boot/docs/2.0.0.RELEASE/api/org/springframework/boot/web/servlet/support/SpringBootServletInitializer.html`)