### PR TITLE
Add minimum version of maven as prerequisite in parent pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@ limitations under the License.
         </plugins>
     </reporting>
 
+  <prerequisites>
+    <maven>3.5</maven>
+  </prerequisites>
+
     <build>
       <pluginManagement>
         <plugins>


### PR DESCRIPTION
Fusion "presubmit" test failing due to missing min maven version.