### PR TITLE
Prepare for 2.0 release of plugins

### DIFF
--- a/appengine-standard-java8/deployAll.sh
+++ b/appengine-standard-java8/deployAll.sh
@@ -26,7 +26,7 @@ do
   (cd "${app}"
       sed --in-place='.xx' "s/<\/runtime>/<\/runtime><service>${app}<\/service>/" \
           src/main/webapp/WEB-INF/appengine-web.xml
-      mvn -B --fail-at-end -q appengine:deploy -Dapp.deploy.version="1" \
+      mvn -B --fail-at-end -q package appengine:deploy -Dapp.deploy.version="1" \
           -Dapp.stage.quickstart=true -Dapp.deploy.force=true -Dapp.deploy.promote=true \
           -Dapp.deploy.project="${GOOGLE_CLOUD_PROJECT}" -DskipTests=true
       mv src/main/webapp/WEB-INF/appengine-web.xml.xx src/main/webapp/WEB-INF/appengine-web.xml)

--- a/appengine-standard-java8/helloworld-gae-launch-dataflow/README.md
+++ b/appengine-standard-java8/helloworld-gae-launch-dataflow/README.md
@@ -61,13 +61,13 @@ detailed instructions.
 ## Maven
 ### Running locally
 
-    mvn appengine:run
+    mvn package appengine:run
 
 To use vist: http://localhost:8080/
 
 ### Deploying
 
-    mvn appengine:deploy
+    mvn package appengine:deploy
 
 To use, visit:  https://YOUR-PROJECT-ID.appspot.com
 

--- a/appengine-standard-java8/helloworld/README.md
+++ b/appengine-standard-java8/helloworld/README.md
@@ -27,13 +27,13 @@ detailed instructions.
 ## Maven
 ### Running locally
 
-    mvn appengine:run
+    mvn package appengine:run
 
 To use vist: http://localhost:8080/
 
 ### Deploying
 
-    mvn appengine:deploy
+    mvn package appengine:deploy
 
 To use vist:  https://YOUR-PROJECT-ID.appspot.com
 

--- a/appengine-standard-java8/helloworld/build.gradle
+++ b/appengine-standard-java8/helloworld/build.gradle
@@ -18,7 +18,7 @@ buildscript {    // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'    // latest App Engine Gradle tasks
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.+'    // latest App Engine Gradle tasks
   }
 }
 

--- a/appengine-standard-java8/kotlin-appengine-standard/README.md
+++ b/appengine-standard-java8/kotlin-appengine-standard/README.md
@@ -25,13 +25,13 @@ detailed instructions.
 ## Maven
 ### Running locally
 
-`mvn appengine:run`
+`mvn package appengine:run`
 
 To use vist: http://localhost:8080/
 
 ### Deploying
 
-`mvn appengine:deploy`
+`mvn package appengine:deploy`
 
 To use vist:  https://YOUR-PROJECT-ID.appspot.com
 

--- a/appengine-standard-java8/kotlin-spark-appengine-standard/README.md
+++ b/appengine-standard-java8/kotlin-spark-appengine-standard/README.md
@@ -27,13 +27,13 @@ detailed instructions.
 ## Maven
 ### Running locally
 
-`mvn appengine:run`
+`mvn package appengine:run`
 
 To use vist: http://localhost:8080/
 
 ### Deploying
 
-`mvn appengine:deploy`
+`mvn package appengine:deploy`
 
 To use vist:  https://YOUR-PROJECT-ID.appspot.com
 

--- a/appengine-standard-java8/kotlin-springboot-appengine-standard/README.md
+++ b/appengine-standard-java8/kotlin-springboot-appengine-standard/README.md
@@ -25,13 +25,13 @@ detailed instructions.
 ## Maven
 ### Running locally
 
-`mvn appengine:run`
+`mvn package appengine:run`
 
 To use visit: http://localhost:8080/
 
 ### Deploying
 
-`mvn appengine:deploy`
+`mvn package appengine:deploy`
 
 To use vist:  https://YOUR-PROJECT-ID.appspot.com
 

--- a/appengine-standard-java8/sparkjava-appengine-standard/README.md
+++ b/appengine-standard-java8/sparkjava-appengine-standard/README.md
@@ -25,13 +25,13 @@ detailed instructions.
 ## Maven
 ### Running locally
 
-`mvn appengine:run`
+`mvn package appengine:run`
 
 To use vist: http://localhost:8080/
 
 ### Deploying
 
-`mvn appengine:deploy`
+`mvn package appengine:deploy`
 
 To use vist:  https://YOUR-PROJECT-ID.appspot.com
 

--- a/appengine-standard-java8/springboot-appengine-standard/README.md
+++ b/appengine-standard-java8/springboot-appengine-standard/README.md
@@ -25,13 +25,13 @@ detailed instructions.
 ## Maven
 ### Running locally
 
-`mvn appengine:run`
+`mvn package appengine:run`
 
 To use vist: http://localhost:8080/
 
 ### Deploying
 
-`mvn appengine:deploy`
+`mvn package appengine:deploy`
 
 To use vist:  https://YOUR-PROJECT-ID.appspot.com
 

--- a/bookshelf/2-structured-data/README.md
+++ b/bookshelf/2-structured-data/README.md
@@ -19,5 +19,5 @@ Most users can get this running by updating the parameters in `pom.xml`.
 
 * Deploy your App
 
-    mvn clean appengine:deploy
+    mvn clean package appengine:deploy
 

--- a/bookshelf/2-structured-data/jenkins.sh
+++ b/bookshelf/2-structured-data/jenkins.sh
@@ -22,7 +22,7 @@ set -xe
 # Make sure it works on GAE7
 
 # Deploy and run selenium tests
-mvn clean appengine:deploy verify \
+mvn clean package appengine:deploy verify \
   -Pselenium \
   -Dbookshelf.endpoint="https://${GOOGLE_VERSION_ID}-dot-${GOOGLE_CLOUD_PROJECT}.appspot.com" \
   -Dapp.deploy.version="${GOOGLE_VERSION_ID}" \

--- a/bookshelf/3-binary-data/README.md
+++ b/bookshelf/3-binary-data/README.md
@@ -22,6 +22,6 @@ to below as `MY-BUCKET`.
 
 * Deploy your App
 
-    mvn clean appengine:deploy \
+    mvn clean package appengine:deploy \
         -Dbookshelf.bucket=MY-BUCKET
 

--- a/bookshelf/3-binary-data/jenkins.sh
+++ b/bookshelf/3-binary-data/jenkins.sh
@@ -18,7 +18,7 @@
 set -ex
 
 # Deploy and run selenium tests
-mvn clean appengine:deploy verify \
+mvn clean package appengine:deploy verify \
   -Dbookshelf.bucket="${GCS_BUCKET}" \
   -Pselenium \
   -Dbookshelf.endpoint="https://${GOOGLE_VERSION_ID}-dot-${GOOGLE_CLOUD_PROJECT}.appspot.com" \

--- a/bookshelf/4-auth/README.md
+++ b/bookshelf/4-auth/README.md
@@ -26,7 +26,7 @@ details.
 
 * Deploy your App
 
-    mvn clean appengine:deploy \
+    mvn clean package appengine:deploy \
         -Dbookshelf.bucket=MY-BUCKET
 
 

--- a/bookshelf/4-auth/jenkins.sh
+++ b/bookshelf/4-auth/jenkins.sh
@@ -20,7 +20,7 @@ set -e
 set +x
 
 # Deploy and run selenium tests
-mvn clean appengine:deploy verify \
+mvn clean package appengine:deploy verify \
   -Dbookshelf.bucket="${GCS_BUCKET}" \
   -Dbookshelf.clientID="${OAUTH2_CLIENT_ID}" \
   -Dbookshelf.clientSecret="${OAUTH2_CLIENT_SECRET}" \

--- a/bookshelf/5-logging/README.md
+++ b/bookshelf/5-logging/README.md
@@ -26,7 +26,7 @@ details.
 
 * Deploy your App
 
-    mvn clean appengine:deploy \
+    mvn clean package appengine:deploy \
         -Dbookshelf.bucket=MY-BUCKET
 
 

--- a/bookshelf/5-logging/jenkins.sh
+++ b/bookshelf/5-logging/jenkins.sh
@@ -20,7 +20,7 @@ set -e
 set +x
 
 # Deploy and run selenium tests
-mvn clean appengine:deploy verify \
+mvn clean package appengine:deploy verify \
   -Dbookshelf.bucket="${GCS_BUCKET}" \
   -Dbookshelf.clientID="${OAUTH2_CLIENT_ID}" \
   -Dbookshelf.clientSecret="${OAUTH2_CLIENT_SECRET}" \

--- a/flexible/tomcat/helloworld/README.md
+++ b/flexible/tomcat/helloworld/README.md
@@ -30,7 +30,7 @@ The samples have files to support both Maven and Gradle.  To use the IDE plugins
   
 ### Deploying
 
-    $ mvn appengine:deploy
+    $ mvn package appengine:deploy
 
 ## Gradle
 [Using Gradle and the App Engine Plugin](https://cloud.google.com/appengine/docs/flexible/java/using-gradle) 

--- a/flexible/tomcat/helloworld/build.gradle
+++ b/flexible/tomcat/helloworld/build.gradle
@@ -18,7 +18,7 @@ buildscript {      // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.+'
     classpath 'org.akhikhl.gretty:gretty:+'
   }
 }

--- a/helloworld-jsp/README.md
+++ b/helloworld-jsp/README.md
@@ -25,7 +25,7 @@ The samples have files to support both Maven and Gradle.  To use the IDE plugins
   
 ### Deploying
 
-    $ mvn appengine:deploy
+    $ mvn package appengine:deploy
 
 ## Gradle
 [Using Gradle and the App Engine Plugin](https://cloud.google.com/appengine/docs/flexible/java/using-gradle) 

--- a/helloworld-jsp/build.gradle
+++ b/helloworld-jsp/build.gradle
@@ -18,7 +18,7 @@ buildscript {      // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.+'
     classpath 'org.akhikhl.gretty:gretty:+'
   }
 }

--- a/helloworld-servlet/README.md
+++ b/helloworld-servlet/README.md
@@ -26,7 +26,7 @@ The samples have files to support both Maven and Gradle.  To use the IDE plugins
   
 ### Deploying
 
-    $ mvn appengine:deploy
+    $ mvn package appengine:deploy
 
 ## Gradle
 [Using Gradle and the App Engine Plugin](https://cloud.google.com/appengine/docs/flexible/java/using-gradle) 

--- a/helloworld-servlet/build.gradle
+++ b/helloworld-servlet/build.gradle
@@ -18,7 +18,7 @@ buildscript {      // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.+'
     classpath 'org.akhikhl.gretty:gretty:+'
   }
 }

--- a/helloworld-springboot/README.md
+++ b/helloworld-springboot/README.md
@@ -84,7 +84,7 @@ These settings should be revisited for production use.
 
 ## Deploy to App Engine flexible environment
 
-1. `mvn appengine:deploy`
+1. `mvn package appengine:deploy`
 1. Visit `http://YOUR_PROJECT.appspot.com`.
 
 Note that deployment to the App Engine flexible environment requires the new


### PR DESCRIPTION
Specifically for 2.0 appengine (cloud sdk based) plugins

- limit current gradle plugin to 1.+ (instead of +), so we can
  gracefully update to 2.0 (or 2.+).

- add in package requirement for running appengine:<goal> on maven,
  get users in the habit of using non-forked plugin goals.