### PR TITLE
Use latest 1.X release for gradle plugin

### DIFF
--- a/appengine-standard-java8/helloworld/build.gradle
+++ b/appengine-standard-java8/helloworld/build.gradle
@@ -18,7 +18,7 @@ buildscript {    // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'    // latest App Engine Gradle tasks
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.+'    // Latest 1.x.x release
   }
 }
 

--- a/flexible/tomcat/helloworld/build.gradle
+++ b/flexible/tomcat/helloworld/build.gradle
@@ -18,7 +18,7 @@ buildscript {      // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.+' // Latest 1.x.x release
     classpath 'org.akhikhl.gretty:gretty:+'
   }
 }

--- a/helloworld-jsp/build.gradle
+++ b/helloworld-jsp/build.gradle
@@ -18,7 +18,7 @@ buildscript {      // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.+' // Latest 1.x.x release
     classpath 'org.akhikhl.gretty:gretty:+'
   }
 }

--- a/helloworld-servlet/build.gradle
+++ b/helloworld-servlet/build.gradle
@@ -18,7 +18,7 @@ buildscript {      // Configuration for building
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:appengine-gradle-plugin:+'
+    classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.+' // Latest 1.x.x release
     classpath 'org.akhikhl.gretty:gretty:+'
   }
 }


### PR DESCRIPTION
limit current gradle plugin to 1.+ (instead of +), so we can gracefully update to 2.0 (or 2.+) when that goes GA.