### PR TITLE
Fix kotlin-springboot-appengine-standard deploy error in periodic tests.

### DIFF
--- a/appengine-standard-java8/kotlin-springboot-appengine-standard/pom.xml
+++ b/appengine-standard-java8/kotlin-springboot-appengine-standard/pom.xml
@@ -31,7 +31,6 @@ limitations under the License.
 
   <properties>
     <java.version>1.8</java.version>
-    <kotlin.version>1.2.41</kotlin.version>
   </properties>
 
   <dependencies>
@@ -68,8 +67,13 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-jre8</artifactId>
-      <version>${kotlin.version}</version>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>1.2.41</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-reflect</artifactId>
+      <version>1.2.41</version>
     </dependency>
   </dependencies>
 
@@ -81,7 +85,7 @@ limitations under the License.
       <plugin>
         <artifactId>kotlin-maven-plugin</artifactId>
         <groupId>org.jetbrains.kotlin</groupId>
-        <version>${kotlin.version}</version>
+        <version>1.2.41</version>
         <configuration>
           <compilerPlugins>
             <plugin>spring</plugin>
@@ -108,7 +112,7 @@ limitations under the License.
             <dependency>
               <groupId>org.jetbrains.kotlin</groupId>
               <artifactId>kotlin-maven-allopen</artifactId>
-              <version>${kotlin.version}</version>
+              <version>1.2.41</version>
             </dependency>
           </dependencies>
       </plugin>


### PR DESCRIPTION
Periodic tests are failing for getting-started-java because the kotlin-springboot-appengine-standard project fails to deploy. This is because the kotlin reflect library is needed as a dependency - when deploying locally, I was getting ClassNotFoundExceptions on kotlin's `KClasses`

Also kotlin-stdlib-jre8 is deprecated and should be replaced with kotlin-stdlib-jdk8.