### PR TITLE
Add CODEOWNERS file to automatically assign reviews to dzlier.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# The java-samples-reviewers team is the default owner for anything not
+# explicitly taken by someone else.
+*                         @GoogleCloudPlatform/java-samples-reviewers


### PR DESCRIPTION
Anyone else who should be added to particular sub projects is welcome to add their names as well, using other CODEOWNERS files as [examples](https://github.com/googleapis/google-cloud-python/blob/master/.github/CODEOWNERS).