### PR TITLE
Fix selenium errors in periodic tests.

### DIFF
--- a/bookshelf-standard/2-structured-data/pom.xml
+++ b/bookshelf-standard/2-structured-data/pom.xml
@@ -35,16 +35,17 @@ Copyright 2016 Google Inc.
     <bookshelf.storageType>datastore</bookshelf.storageType>   <!-- datastore or cloudsql -->
 
     <sql.dbName>bookshelf</sql.dbName>                        <!-- A reasonable default -->
-<!-- Instance Connection Name - project:region:dbName -->
-<!-- -Dsql.instanceName=localhost to use a local MySQL server -->
-    <sql.instanceName>DATABASE-connectionName-HERE</sql.instanceName> <!-- See `gcloud sql instances describe [instanceName]` -->
+    <!-- Instance Connection Name - project:region:dbName -->
+    <!-- -Dsql.instanceName=localhost to use a local MySQL server -->
+    <sql.instanceName>DATABASE-connectionName-HERE
+    </sql.instanceName> <!-- See `gcloud sql instances describe [instanceName]` -->
     <sql.userName>root</sql.userName>                         <!-- A reasonable default -->
     <sql.password>MYSQL-ROOT-PASSWORD-HERE</sql.password> <!-- -Dsql.password=myRootPassword1234 -->
     <!-- [END config] -->
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source> <!-- REQUIRED -->
-    <maven.compiler.target>1.7</maven.compiler.target> <!-- REQUIRED -->
+    <maven.compiler.source>1.8</maven.compiler.source> <!-- REQUIRED -->
+    <maven.compiler.target>1.8</maven.compiler.target> <!-- REQUIRED -->
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
     <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
@@ -109,11 +110,10 @@ Copyright 2016 Google Inc.
     </dependency>
 
     <dependency>                        <!-- Google Core Libraries for Java -->
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>  <!-- https://github.com/google/guava/wiki -->
-        <!-- Guava v21.0 doesn't support Java7 -->
-        <version>20.0</version>
-        <scope>compile</scope>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>  <!-- https://github.com/google/guava/wiki -->
+      <version>23.0</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>                        <!-- http://www.joda.org/joda-time/ -->
@@ -130,11 +130,7 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
-    </dependency>
-    <!-- Selenium chokes without this, for some reason. -->
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <dependency>                        <!-- Google Cloud Client Library for Java -->
       <groupId>com.google.cloud</groupId>
@@ -144,9 +140,9 @@ Copyright 2016 Google Inc.
 
   <build>
     <!-- Optional - for hot reload of the web application when using an IDE Eclipse / IDEA -->
-    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes
+    </outputDirectory>
     <plugins>
-
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>

--- a/bookshelf-standard/2-structured-data/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf-standard/2-structured-data/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -192,18 +193,21 @@ public class UserJourneyTestIT {
       WebElement button = checkLandingPage();
 
       button.click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/create$"));
 
       checkAddBookPage();
 
       submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/read\\?id=[0-9]+$"));
 
       checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
 
       // Now check the list of books for the one we just submitted
       driver.findElement(By.linkText("Books")).click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/$"));
 
       checkBookList(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
     } catch (Exception e) {

--- a/bookshelf-standard/3-binary-data/pom.xml
+++ b/bookshelf-standard/3-binary-data/pom.xml
@@ -35,9 +35,10 @@ Copyright 2016 Google Inc.
     <bookshelf.storageType>datastore</bookshelf.storageType>   <!-- datastore or cloudsql -->
 
     <sql.dbName>bookshelf</sql.dbName>                        <!-- A reasonable default -->
-<!-- Instance Connection Name - project:region:dbName -->
-<!-- -Dsql.instanceName=localhost to use a local MySQL server -->
-    <sql.instanceName>DATABASE-connectionName-HERE</sql.instanceName> <!-- See `gcloud sql instances describe [instanceName]` -->
+    <!-- Instance Connection Name - project:region:dbName -->
+    <!-- -Dsql.instanceName=localhost to use a local MySQL server -->
+    <sql.instanceName>DATABASE-connectionName-HERE
+    </sql.instanceName> <!-- See `gcloud sql instances describe [instanceName]` -->
     <sql.userName>root</sql.userName>                         <!-- A reasonable default -->
     <sql.password>MYSQL-ROOT-PASSWORD-HERE</sql.password> <!-- -Dsql.password=myRootPassword1234 -->
 
@@ -117,11 +118,10 @@ Copyright 2016 Google Inc.
     </dependency>
 
     <dependency>                        <!-- Google Core Libraries for Java -->
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>  <!-- https://github.com/google/guava/wiki -->
-        <!-- Guava v21.0 doesn't support Java7 -->
-        <version>20.0</version>
-        <scope>compile</scope>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>  <!-- https://github.com/google/guava/wiki -->
+      <version>23.0</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>                        <!-- http://www.joda.org/joda-time/ -->
@@ -144,6 +144,12 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
+      <version>3.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-chrome-driver</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <!-- Selenium chokes without this, for some reason. -->
     <dependency>
@@ -159,9 +165,9 @@ Copyright 2016 Google Inc.
 
   <build>
     <!-- Optional - for hot reload of the web application when using an IDE Eclipse / IDEA -->
-    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes
+    </outputDirectory>
     <plugins>
-
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>

--- a/bookshelf-standard/3-binary-data/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf-standard/3-binary-data/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -32,6 +32,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -195,18 +196,21 @@ public class UserJourneyTestIT {
       WebElement button = checkLandingPage();
 
       button.click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/create$"));
 
       checkAddBookPage();
 
       submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, filePath);
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/read\\?id=[0-9]+$"));
 
       checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, IMAGE_FILENAME);
 
       // Now check the list of books for the one we just submitted
       driver.findElement(By.linkText("Books")).click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/$"));
 
       checkBookList(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, IMAGE_FILENAME);
     } catch (Exception e) {

--- a/bookshelf-standard/4-auth/pom.xml
+++ b/bookshelf-standard/4-auth/pom.xml
@@ -35,14 +35,15 @@ Copyright 2016 Google Inc.
     <bookshelf.storageType>datastore</bookshelf.storageType>   <!-- datastore or cloudsql -->
 
     <sql.dbName>bookshelf</sql.dbName>                        <!-- A reasonable default -->
-<!-- Instance Connection Name - project:region:dbName -->
-<!-- -Dsql.instanceName=localhost to use a local MySQL server -->
-    <sql.instanceName>DATABASE-connectionName-HERE</sql.instanceName> <!-- See `gcloud sql instances describe [instanceName]` -->
+    <!-- Instance Connection Name - project:region:dbName -->
+    <!-- -Dsql.instanceName=localhost to use a local MySQL server -->
+    <sql.instanceName>DATABASE-connectionName-HERE
+    </sql.instanceName> <!-- See `gcloud sql instances describe [instanceName]` -->
     <sql.userName>root</sql.userName>                         <!-- A reasonable default -->
     <sql.password>MYSQL-ROOT-PASSWORD-HERE</sql.password> <!-- -Dsql.password=myRootPassword1234 -->
 
     <bookshelf.bucket>BUCKET-NAME-HERE</bookshelf.bucket> <!-- eg project-id.appspot.com -->
-  <!-- [END config] -->
+    <!-- [END config] -->
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.7</maven.compiler.source> <!-- REQUIRED -->
@@ -117,11 +118,10 @@ Copyright 2016 Google Inc.
     </dependency>
 
     <dependency>                        <!-- Google Core Libraries for Java -->
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>  <!-- https://github.com/google/guava/wiki -->
-        <!-- Guava v21.0 doesn't support Java7 -->
-        <version>20.0</version>
-        <scope>compile</scope>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>  <!-- https://github.com/google/guava/wiki -->
+      <version>23.0</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>                        <!-- http://www.joda.org/joda-time/ -->
@@ -144,6 +144,12 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
+      <version>3.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-chrome-driver</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <!-- Selenium chokes without this, for some reason. -->
     <dependency>
@@ -159,9 +165,9 @@ Copyright 2016 Google Inc.
 
   <build>
     <!-- Optional - for hot reload of the web application when using an IDE Eclipse / IDEA -->
-    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes
+    </outputDirectory>
     <plugins>
-
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>

--- a/bookshelf-standard/4-auth/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf-standard/4-auth/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -215,43 +216,48 @@ public class UserJourneyTestIT {
         WebElement loginButton = driver.findElement(By.linkText("Login"));
 
         loginButton.click();
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches("login"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            "login"));
 
         login(EMAIL);
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches("/books"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            "/books"));
 
         button = checkLandingPage(EMAIL);
 
         button.click();
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            ".*/create$"));
 
         checkAddBookPage();
 
         submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-        (new WebDriverWait(driver, 10)).until(
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
             ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
 
         checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, EMAIL);
 
         logout(EMAIL);
-        (new WebDriverWait(driver, 10)).until(
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
             ExpectedConditions.presenceOfElementLocated(By.linkText("Login")));
 
       } else {
         button.click();
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            ".*/create$"));
 
         checkAddBookPage();
 
         submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-        (new WebDriverWait(driver, 10)).until(
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
             ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
 
         checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, "Anonymous");
 
         // Now check the list of books for the one we just submitted
         driver.findElement(By.linkText("Books")).click();
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/$"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            ".*/$"));
 
         checkBookList(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
       }

--- a/bookshelf-standard/5-logging/pom.xml
+++ b/bookshelf-standard/5-logging/pom.xml
@@ -35,14 +35,15 @@ Copyright 2016 Google Inc.
     <bookshelf.storageType>datastore</bookshelf.storageType>   <!-- datastore or cloudsql -->
 
     <sql.dbName>bookshelf</sql.dbName>                        <!-- A reasonable default -->
-<!-- Instance Connection Name - project:region:dbName -->
-<!-- -Dsql.instanceName=localhost to use a local MySQL server -->
-    <sql.instanceName>DATABASE-connectionName-HERE</sql.instanceName> <!-- See `gcloud sql instances describe [instanceName]` -->
+    <!-- Instance Connection Name - project:region:dbName -->
+    <!-- -Dsql.instanceName=localhost to use a local MySQL server -->
+    <sql.instanceName>DATABASE-connectionName-HERE
+    </sql.instanceName> <!-- See `gcloud sql instances describe [instanceName]` -->
     <sql.userName>root</sql.userName>                         <!-- A reasonable default -->
     <sql.password>MYSQL-ROOT-PASSWORD-HERE</sql.password> <!-- -Dsql.password=myRootPassword1234 -->
 
     <bookshelf.bucket>BUCKET-NAME-HERE</bookshelf.bucket> <!-- eg project-id.appspot.com -->
-  <!-- [END config] -->
+    <!-- [END config] -->
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.7</maven.compiler.source> <!-- REQUIRED -->
@@ -117,11 +118,10 @@ Copyright 2016 Google Inc.
     </dependency>
 
     <dependency>                        <!-- Google Core Libraries for Java -->
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>  <!-- https://github.com/google/guava/wiki -->
-        <!-- Guava v21.0 doesn't support Java7 -->
-        <version>20.0</version>
-        <scope>compile</scope>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>  <!-- https://github.com/google/guava/wiki -->
+      <version>23.0</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>                        <!-- http://www.joda.org/joda-time/ -->
@@ -144,6 +144,12 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
+      <version>3.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-chrome-driver</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <!-- Selenium chokes without this, for some reason. -->
     <dependency>
@@ -159,9 +165,9 @@ Copyright 2016 Google Inc.
 
   <build>
     <!-- Optional - for hot reload of the web application when using an IDE Eclipse / IDEA -->
-    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+    <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes
+    </outputDirectory>
     <plugins>
-
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine-maven-plugin</artifactId>

--- a/bookshelf-standard/5-logging/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf-standard/5-logging/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -227,43 +228,48 @@ public class UserJourneyTestIT {
       if (LOCAL_TEST) {
         WebElement loginButton = driver.findElement(By.linkText("Login"));
         loginButton.click();
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches("login"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            "login"));
 
         login(EMAIL);
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches("/books"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            "/books"));
 
         button = checkLandingPage(EMAIL);
 
         button.click();
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            ".*/create$"));
 
         checkAddBookPage();
 
         submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-        (new WebDriverWait(driver, 10)).until(
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
             ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
 
         checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, EMAIL);
 
         logout(EMAIL);
-        (new WebDriverWait(driver, 10)).until(
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
             ExpectedConditions.presenceOfElementLocated(By.linkText("Login")));
 
       } else {
         button.click();
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            ".*/create$"));
 
         checkAddBookPage();
 
         submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-        (new WebDriverWait(driver, 10)).until(
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
             ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
 
         checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, "Anonymous");
 
         // Now check the list of books for the one we just submitted
         driver.findElement(By.linkText("Books")).click();
-        (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/$"));
+        (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+            ".*/$"));
 
         checkBookList(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
       }

--- a/bookshelf-standard/pom.xml
+++ b/bookshelf-standard/pom.xml
@@ -32,7 +32,7 @@ Copyright 2016 Google Inc.
 
   <properties>
     <appengine-maven.version>1.9.48</appengine-maven.version>
-    <google-cloud.version>0.10.0-alpha</google-cloud.version>
+    <google-cloud.version>0.47.0-alpha</google-cloud.version>
   </properties>
 
   <profiles>
@@ -92,7 +92,13 @@ Copyright 2016 Google Inc.
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-server</artifactId>
-        <version>3.0.1</version>
+        <version>3.3.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.seleniumhq.selenium</groupId>
+        <artifactId>selenium-chrome-driver</artifactId>
+        <version>3.3.1</version>
         <scope>test</scope>
       </dependency>
       <!-- Selenium chokes without this, for some reason. -->

--- a/bookshelf/2-structured-data/pom.xml
+++ b/bookshelf/2-structured-data/pom.xml
@@ -156,10 +156,12 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-chrome-driver</artifactId>
+      <version>3.3.1</version>
     </dependency>
   </dependencies>
 

--- a/bookshelf/2-structured-data/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf/2-structured-data/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -118,7 +119,7 @@ public class UserJourneyTestIT {
         "Description", inputContainers.get(3).findElement(By.tagName("label")).getText());
 
     // The rest should be hidden
-    for (Iterator<WebElement> iter = inputContainers.listIterator(4); iter.hasNext();) {
+    for (Iterator<WebElement> iter = inputContainers.listIterator(4); iter.hasNext(); ) {
       WebElement el = iter.next();
       assertTrue(el.getAttribute("class").indexOf("hidden") >= 0);
     }
@@ -153,7 +154,7 @@ public class UserJourneyTestIT {
         .indexOf("placekitten") > 0);
     assertTrue("Should show title",
         driver.findElement(By.cssSelector(".book-title")).getText()
-        .startsWith(title));
+            .startsWith(title));
     assertEquals("Should show author",
         "By " + author, driver.findElement(By.cssSelector(".book-author")).getText());
     assertEquals("Should show description",
@@ -178,7 +179,7 @@ public class UserJourneyTestIT {
     for (int i = 0; i < numRetries; i++) {
       driver.get(endpoint);
       if (driver.getTitle().matches("50[0-9]|[Ee]rror")) {
-        Thread.sleep(5000 + (int)(Math.random() * Math.pow(2, i + 1)) * 1000);
+        Thread.sleep(5000 + (int) (Math.random() * Math.pow(2, i + 1)) * 1000);
       } else {
         return;
       }
@@ -196,18 +197,21 @@ public class UserJourneyTestIT {
       WebElement button = checkLandingPage();
 
       button.click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/create$"));
 
       checkAddBookPage();
 
       submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/read\\?id=[0-9]+$"));
 
       checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
 
       // Now check the list of books for the one we just submitted
       driver.findElement(By.linkText("Books")).click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/$"));
 
       checkBookList(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
     } catch (Exception e) {

--- a/bookshelf/3-binary-data/pom.xml
+++ b/bookshelf/3-binary-data/pom.xml
@@ -158,10 +158,12 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-chrome-driver</artifactId>
+      <version>3.3.1</version>
     </dependency>
   </dependencies>
 

--- a/bookshelf/3-binary-data/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf/3-binary-data/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -32,6 +32,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -198,18 +199,21 @@ public class UserJourneyTestIT {
       WebElement button = checkLandingPage();
 
       button.click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/create$"));
 
       checkAddBookPage();
 
       submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, filePath);
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/read\\?id=[0-9]+$"));
 
       checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, IMAGE_FILENAME);
 
       // Now check the list of books for the one we just submitted
       driver.findElement(By.linkText("Books")).click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/$"));
 
       checkBookList(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION, IMAGE_FILENAME);
     } catch (Exception e) {

--- a/bookshelf/4-auth/pom.xml
+++ b/bookshelf/4-auth/pom.xml
@@ -177,10 +177,12 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-chrome-driver</artifactId>
+      <version>3.3.1</version>
     </dependency>
   </dependencies>
 

--- a/bookshelf/4-auth/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf/4-auth/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -181,18 +182,20 @@ public class UserJourneyTestIT {
       WebElement button = checkLandingPage();
 
       button.click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/create$"));
 
       checkAddBookPage();
 
       submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/read\\?id=[0-9]+$"));
 
       checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
 
       // Now make sure login at least nominally works.
       driver.findElement(By.linkText("Login")).click();
-      (new WebDriverWait(driver, 10)).until(
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
           ExpectedConditions.urlMatches("https://accounts.google.com"));
       // ...aaaaand that's about as far as I can test without a Real Account.
     } catch (Exception e) {

--- a/bookshelf/5-logging/pom.xml
+++ b/bookshelf/5-logging/pom.xml
@@ -175,10 +175,12 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-chrome-driver</artifactId>
+      <version>3.3.1</version>
     </dependency>
   </dependencies>
 

--- a/bookshelf/5-logging/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf/5-logging/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -185,18 +186,20 @@ public class UserJourneyTestIT {
       WebElement button = checkLandingPage();
 
       button.click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/create$"));
 
       checkAddBookPage();
 
       submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/read\\?id=[0-9]+$"));
 
       checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
 
       // Now make sure login at least nominally works.
       driver.findElement(By.linkText("Login")).click();
-      (new WebDriverWait(driver, 10)).until(
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
           ExpectedConditions.urlMatches("https://accounts.google.com"));
       // ...aaaaand that's about as far as I can test without a Real Account.
     } catch (Exception e) {

--- a/bookshelf/6-gce/pom.xml
+++ b/bookshelf/6-gce/pom.xml
@@ -175,10 +175,12 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-chrome-driver</artifactId>
+      <version>3.3.1</version>
     </dependency>
   </dependencies>
 

--- a/bookshelf/6-gce/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf/6-gce/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -167,18 +168,20 @@ public class UserJourneyTestIT {
       WebElement button = checkLandingPage();
 
       button.click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/create$"));
 
       checkAddBookPage();
 
       submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/read\\?id=[0-9]+$"));
 
       checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
 
       // Now make sure login at least nominally works.
       driver.findElement(By.linkText("Login")).click();
-      (new WebDriverWait(driver, 10)).until(
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
           ExpectedConditions.urlMatches("https://accounts.google.com"));
       // ...aaaaand that's about as far as I can test without a Real Account.
     } catch (Exception e) {

--- a/bookshelf/optional-kubernetes-engine/pom.xml
+++ b/bookshelf/optional-kubernetes-engine/pom.xml
@@ -175,10 +175,12 @@ Copyright 2016 Google Inc.
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server</artifactId>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-chrome-driver</artifactId>
+      <version>3.3.1</version>
     </dependency>
   </dependencies>
 

--- a/bookshelf/optional-kubernetes-engine/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
+++ b/bookshelf/optional-kubernetes-engine/src/test/java/com/example/getstarted/basicactions/UserJourneyTestIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 
@@ -166,18 +167,20 @@ public class UserJourneyTestIT {
       WebElement button = checkLandingPage();
 
       button.click();
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/create$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/create$"));
 
       checkAddBookPage();
 
       submitForm(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
-      (new WebDriverWait(driver, 10)).until(ExpectedConditions.urlMatches(".*/read\\?id=[0-9]+$"));
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(ExpectedConditions.urlMatches(
+          ".*/read\\?id=[0-9]+$"));
 
       checkReadPage(TITLE, AUTHOR, PUBLISHED_DATE, DESCRIPTION);
 
       // Now make sure login at least nominally works.
       driver.findElement(By.linkText("Login")).click();
-      (new WebDriverWait(driver, 10)).until(
+      (new WebDriverWait(driver, Duration.ofSeconds(10))).until(
           ExpectedConditions.urlMatches("https://accounts.google.com"));
       // ...aaaaand that's about as far as I can test without a Real Account.
     } catch (Exception e) {


### PR DESCRIPTION
Fusion period tests are failing due to a deprecated constructor of `WebDriverWait`.

Along with the update, Guava also needed to be updated to properly support the `until` function in `FluentWait`.