### PR TITLE
Update GCE Getting Started project to build directly from base repo.

### DIFF
--- a/gce/makeProject
+++ b/gce/makeProject
@@ -185,7 +185,7 @@ gce-many)
 # [START getting_started_add_backend_service]
   gcloud compute backend-services add-backend $SERVICE \
     --instance-group $GROUP \
-    --instance-group-zone $ZONE
+    --instance-group-zone $ZONE \
     --global
 # [END getting_started_add_backend_service]
 

--- a/gce/pom.xml
+++ b/gce/pom.xml
@@ -26,16 +26,18 @@ Copyright 2019 Google LLC
   <parent>
     <groupId>com.google.cloud.samples</groupId>
     <artifactId>shared-configuration</artifactId>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
+    <relativePath></relativePath>
   </parent>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
     <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
+    <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.war.filteringDeploymentDescriptors>true</maven.war.filteringDeploymentDescriptors>
   </properties>
 


### PR DESCRIPTION
Previously the getting started java workflow required cloning into a personal source repo and uploading a jar to storage.

This change enables removing both those dependencies, instead allowing the user to build and run the server directly from GoogleCloudPlatform/getting-started-java from Cloud Shell.