### PR TITLE
fix root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@ limitations under the License.
     <module>bookshelf/3-binary-data</module>
     <module>bookshelf/4-auth</module>
     <module>bookshelf/5-logging</module>
-    <module>bookshelf/optional-kubernetes-engine</module>
     <module>bookshelf-standard/2-structured-data</module>
     <module>bookshelf-standard/3-binary-data</module>
     <module>bookshelf-standard/4-auth</module>


### PR DESCRIPTION
It looks like the deletions from a recent PR didn't fully get excised
from the root pom.  This removes the remaining reference.

PR where the files where deleted:
https://github.com/GoogleCloudPlatform/getting-started-java/pull/440