### PR TITLE
Update renovate to use new "rebaseWhen" flag.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,6 @@
     "automerge"
   ],
   "prConcurrentLimit": 0,
-  "rebaseStalePrs": false,
+  "rebaseWhen": "never",
   "masterIssue": true
 }


### PR DESCRIPTION
"rebaseStalePrs" has been deprecated:

https://docs.renovatebot.com/configuration-options/#rebasewhen