### PR TITLE
Fix Maven URL in startup-script.sh

### DIFF
--- a/gce/scripts/startup-script.sh
+++ b/gce/scripts/startup-script.sh
@@ -32,7 +32,7 @@ mkdir -p /opt/jetty/temp
 mkdir -p /var/log/jetty
 
 # Get Jetty
-curl -L http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.13.v20181111/jetty-distribution-9.4.13.v20181111.tar.gz -o jetty9.tgz
+curl -L https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.13.v20181111/jetty-distribution-9.4.13.v20181111.tar.gz -o jetty9.tgz
 tar xf jetty9.tgz  --strip-components=1 -C /opt/jetty
 
 # Add a Jetty User


### PR DESCRIPTION
Per this post: https://central.sonatype.org/articles/2019/Jul/15/central-http-deprecation-update/

http://central.maven.org is no longer supportd. https://repo1.maven.org (note the https requirement) will continue to be supported. I ran into this while setting up my own GCP project and have confirmed that the script works with this change (see https://github.com/jalexanderqed/gcloud-website/blob/master/scripts/startup-script.sh).